### PR TITLE
Add GPT-2 input method demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # xigua
+
+This repository provides a minimal demo of an input method powered by a Transformer model. The demo uses the pre-trained GPT-2 model to predict the next word based on context. As you type characters, the script updates candidate suggestions.
+
+## Usage
+
+Install dependencies (requires internet access):
+
+```bash
+pip install torch transformers
+```
+
+Run the demo:
+
+```bash
+python demo.py
+```
+
+You will be prompted for an initial context. Then, type characters one by one. After each character, the script displays suggestions for completing the current word. Press Enter to accept the word and continue, or type `/quit` to exit.

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,49 @@
+import torch
+from transformers import GPT2LMHeadModel, GPT2Tokenizer
+
+# Load pre-trained GPT-2 tokenizer and model
+# Using small gpt2 model for demonstration
+
+tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
+model = GPT2LMHeadModel.from_pretrained('gpt2')
+model.eval()
+
+
+def get_suggestions(context: str, prefix: str, k: int = 5):
+    """Return up to k suggestions for the next word starting with prefix."""
+    # Encode the context
+    input_ids = tokenizer.encode(context, return_tensors='pt')
+    with torch.no_grad():
+        logits = model(input_ids).logits[0, -1]
+    # Take a larger top_k to improve chances of matching prefix
+    topk = torch.topk(logits, k=50)
+    suggestions = []
+    for token_id in topk.indices.tolist():
+        token_str = tokenizer.decode([token_id]).strip()
+        if token_str.startswith(prefix):
+            suggestions.append(token_str)
+        if len(suggestions) >= k:
+            break
+    return suggestions
+
+
+def interactive_loop():
+    print("Simple input method demo using GPT-2. Type /quit to exit.")
+    context = input("Initial context: ")
+    prefix = ""
+    while True:
+        ch = input("Type next character (Enter to commit word): ")
+        if ch == "/quit":
+            break
+        if ch == "":
+            context += prefix + " "
+            prefix = ""
+            print(f"\nUpdated context: {context}\n")
+            continue
+        prefix += ch
+        suggestions = get_suggestions(context, prefix)
+        print("Suggestions:", suggestions)
+
+
+if __name__ == "__main__":
+    interactive_loop()


### PR DESCRIPTION
## Summary
- add a Python demo that uses GPT-2 to suggest next words as characters are typed
- document installation and usage steps in README

## Testing
- `python demo.py` *(fails: No module named 'torch')*
- `pip install torch transformers` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_6898c3686efc832cb91f6ffc3e062099